### PR TITLE
Extend simulator support to include arm64 architecture

### DIFF
--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -112,7 +112,7 @@ open class Device {
             case "iPod9,1":                                  return .iPodTouch7Gen
 
             /*** Simulator ***/
-            case "i386", "x86_64":                           return .simulator
+            case "i386", "x86_64", "arm64":                  return .simulator
 
             default:                                         return .unknown
         }
@@ -127,7 +127,7 @@ open class Device {
             return .iPad
         } else if versionCode.contains("iPod") {
             return .iPod
-        } else if versionCode == "i386" || versionCode == "x86_64" {
+        } else if versionCode == "i386" || versionCode == "x86_64" || versionCode == "arm64" {
             return .simulator
         } else {
             return .unknown


### PR DESCRIPTION
- Add 'arm64' to the list of architectures recognized as simulators in Device.swift.
- This update ensures compatibility with simulators running on Apple Silicon Macs, enhancing the development experience on these newer platforms.